### PR TITLE
Amending if-codelet to support test/then/else fields

### DIFF
--- a/codetree.py
+++ b/codetree.py
@@ -4,6 +4,7 @@
 
 import json
 import abc
+from str2bool import str2bool
 
 class Codelet( abc.ABC ):
 	"""
@@ -56,13 +57,21 @@ class StringCodelet( ConstantCodelet ):
 
 
 class IntCodelet( ConstantCodelet ):
-
 	KIND = "int"
 
 	def __init__( self, *, value, radix=10, **kwargs ):
 		super().__init__( **kwargs )
 		self._value = int( value, radix )
-	
+
+
+class BoolCodelet( ConstantCodelet ):
+	KIND = "bool"
+
+	def __init__( self, *, value, **kwargs ):
+		super().__init__( **kwargs )
+		self._value = str2bool( value )
+
+
 class IdCodelet( Codelet ):
 
 	KIND = "id"
@@ -79,13 +88,16 @@ class IfCodelet( Codelet ):
 
 	KIND = "if"
 
-	def __init__( self, *, testactions, elseaction, **kwargs ):
+	# Slightly awkward because the constructor for an if-codelet uses a Python
+	# reserved word (else) as a keyword-argument.
+	def __init__( self, *, test, then, **kwargs ):
+		self._else = kwargs.pop( 'else', None )
 		super().__init__( **kwargs )
-		self._testActions = testactions
-		self._elseAction = elseaction
+		self._test = test
+		self._then = then
 
 	def encodeAsJSON( self, encoder ):
-		return dict( kind=self.KIND, testactions=self._testActions, elseaction=self.elseAction )
+		return dict( kind=self.KIND, test=self._test, then=self._then )
 
 class BindingCodelet( Codelet ):
 

--- a/test_codetree.py
+++ b/test_codetree.py
@@ -1,0 +1,14 @@
+import codetree
+import io
+
+def test_deserialise():
+    # Arrange
+    jdata = '{ "kind":"if", "test": {"kind":"bool", "value":"true"}, "then": {"kind":"string", "value":"yes"}, "else": {"kind":"string", "value":"yes"} }'
+    # Act
+    data = codetree.deserialise( io.StringIO( jdata ) )
+    # Assert
+    assert isinstance( data, codetree.IfCodelet )
+    assert isinstance( data._test, codetree.BoolCodelet )
+    assert isinstance( data._then, codetree.StringCodelet )
+    assert isinstance( data._else, codetree.StringCodelet )
+


### PR DESCRIPTION
The If-codelet implementation in Python needed updating. The original design was LISP-like with a sequence of condition-action pairs and a fallback, corresponding to `if...then...elif...then...elif...then...else...endif`. This was directly taken from Ginger. However Ginger's intermediate structure (MinXML) is more suited to this style than Nutmeg's (JSON). [Aside: actually my new project JinXML would be far better - but that's another story.]

So we decided to make the structure a bit less complicated and revert to `if TEST then THEN else ELSE endif`. This definitely makes it easier to work with for simple examples.