### PR TITLE
Demonstrator of the decorator @NutmegParserExtension.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 /_dist/
 /_working/
 /attic/
+/scrapbook/

--- a/codetree.py
+++ b/codetree.py
@@ -335,9 +335,3 @@ def deserialise( src ):
 	Reads a text stream in JSON format into a nutmeg-tree.
 	"""
 	return json.load( src, object_hook=codeTreeJSONHook )
-
-###---###
-
-#
-# if __name__ == "__main__":
-# 	B = json.load( open( 'codetree-examples/binding.codetree.json', 'r' ), object_hook=codeTreeJSONHook)

--- a/codetree.py
+++ b/codetree.py
@@ -14,13 +14,12 @@ class Codelet( abc.ABC ):
 
 	KIND_PROPERTY = "kind"
 
-	def __init__( self, **kwargs ):
+	def __init__( self, kind=None, **kwargs ):
 		"""
 		The keyword-arguments are going to be supplied from the deserialisd
 		JSON, so the keywords will match the object-fields from the JSON,
 		although the values will be codelets and not plain-JSON objects.
 		"""
-		del kwargs[Codelet.KIND_PROPERTY]
 		self._kwargs = kwargs
 
 	def serialise( self, dst ):

--- a/codetree.py
+++ b/codetree.py
@@ -304,14 +304,15 @@ def makeDeserialisationTable():
 	Scans the class hierarchy under CodeTree to find all the leaf classes
 	and then adds them to a mapping from kinds to constructors.
 	"""
-	mapping_table = {}
-	list = [ Codelet ]
-	while list:
-		codetree_class = list.pop()
+	mapping_table = {}			# This is the table we are trying to complete.
+	L = [ Codelet ]				# Use as a quick and dirty stack.
+	while L:
+		codetree_class = L.pop()
 		subclasses = codetree_class.__subclasses__()
 		if subclasses:
-			list.extend( subclasses )
+			L.extend( subclasses )
 		else:
+			# Found a leaf class, so add to mapping.
 			mapping_table[ codetree_class.KIND ] = codetree_class
 	return mapping_table
 
@@ -319,11 +320,11 @@ def makeDeserialisationTable():
 DESERIALISATION_TABLE = makeDeserialisationTable()
 
 def codeTreeJSONHook( jdict ):
-	'''
+	"""
 	This is an extension method for Python's json deserialiser. It detects
 	items that are of the right kind and calls the matching constructor
 	on using the JSON object to supply the keyword-parameters.
-	'''
+    """
 	if Codelet.KIND_PROPERTY in jdict:
 		e = jdict[Codelet.KIND_PROPERTY ]
 		return DESERIALISATION_TABLE[e]( **jdict )

--- a/dot_nutmeg_parser.py
+++ b/dot_nutmeg_parser.py
@@ -1,0 +1,6 @@
+from nutmeg_extensions import NutmegParserExtension
+from parser import parseFromFileObject
+
+@NutmegParserExtension(r'(.*)\.nutmeg$')
+def dot_txt_parser( file_object, match ):
+    yield from parseFromFileObject( file_object )

--- a/dot_txt_parser.py
+++ b/dot_txt_parser.py
@@ -1,0 +1,21 @@
+"""
+This is an example parser extension. It is a trivial demo as it sucks in
+the whole of a file as a string; it would be more sensible to implement it
+as a future string, or at least check the size of the file is small before
+unconditionally loading it.
+
+The most interesting design question is whether or not the parser should
+return a single codetree _or_ return a codetree iterator. We have chosen the
+latter but I expect it is an issue that will surface repeatedly.
+"""
+
+from nutmeg_extensions import NutmegParserExtension
+from codetree import StringCodelet, IdCodelet, BindingCodelet
+
+@NutmegParserExtension(r'(.*)\.txt$')
+def dot_txt_parser( file_object, match ):
+    varname = match.group(1)
+    contents = file_object.read()
+    rhs = StringCodelet( value = contents )
+    lhs = IdCodelet( name=varname, reftype='const' )
+    yield BindingCodelet( lhs=lhs, rhs=rhs )

--- a/launcher.py
+++ b/launcher.py
@@ -30,11 +30,8 @@ class Launcher:
 class ParseLauncher(Launcher):
 
     def launch(self):
-        """
-        This is a dummy function to show how the launcher and the basic
-        functionality will relate to each other.
-        """
         fname = self._args.input.name
+        # Note that stdin and stdout are to be treated as Nutmeg code.
         effective_fname = '.nutmeg' if fname == '<stdin>' or fname == '<stdout>' else fname
         (match, parser) = nutmeg_extensions.findMatchingParser( effective_fname  )
         for codelet in parser( self._args.input, match ):

--- a/launcher.py
+++ b/launcher.py
@@ -1,9 +1,11 @@
 import argparse
 import sys
-from parser import parseFromFileObject
 
 import nutmeg_extensions
+
+### WARNING: The next two imports do indeed do something useful - via decorators.
 import dot_txt_parser
+import dot_nutmeg_parser
 
 ###############################################################################
 # Components
@@ -12,22 +14,12 @@ import dot_txt_parser
 # There will be a class for each component - and they will all be moved
 # to their own modules. 
 
-class Parser:
-	"""
-	A placeholder class that does something a little
-	like the real parser.
-	"""
-	def parse( self, src ):
-		( match, parser ) = nutmeg_extensions.findMatchingParser( src.name )
-		return parser( src, match )
-
-
 ###############################################################################
 # Classes that implement the command-line functionality for each component
 ###############################################################################
 
-
 class Launcher:
+
     def __init__(self, args):
         self._args = args
 
@@ -42,31 +34,30 @@ class ParseLauncher(Launcher):
         This is a dummy function to show how the launcher and the basic
         functionality will relate to each other.
         """
-        for codelet in parseFromFileObject( self._args.input ):
-            codelet.serialise(self._args.output)
+        fname = self._args.input.name
+        effective_fname = '.nutmeg' if fname == '<stdin>' or fname == '<stdout>' else fname
+        (match, parser) = nutmeg_extensions.findMatchingParser( effective_fname  )
+        for codelet in parser( self._args.input, match ):
+            codelet.serialise( self._args.output )
 
 
 class ResolveLauncher(Launcher):
     """Placeholder"""
-
     pass
 
 
 class OptimiseLauncher(Launcher):
     """Placeholder"""
-
     pass
 
 
 class GenCodeLauncher(Launcher):
     """Placeholder"""
-
     pass
 
 
 class CompileLauncher(Launcher):
     """Placeholder"""
-
     pass
 
 
@@ -75,8 +66,11 @@ class RunLauncher(Launcher):
     We expect this will fork-and-exec into the C# monolithic runtime-engine 
     after preparing the arguments. 
     """
-
     pass
+
+###############################################################################
+# Main entry point - parses the options and launches the right phase.
+###############################################################################
 
 def main():
     parser = argparse.ArgumentParser(
@@ -128,9 +122,9 @@ def main():
     args.mode(args).launch()
 
 
-###############################################################################
-# The command-line option parser
-###############################################################################
+################################################################################
+# This is the top-level entry point for the whole Nutmeg system.
+################################################################################
 
 if __name__ == "__main__":
     main()

--- a/launcher.py
+++ b/launcher.py
@@ -3,6 +3,9 @@ import io
 import sys
 import codetree
 
+import nutmeg_extensions
+import dot_txt_parser
+
 ###############################################################################
 # Components 
 ###############################################################################
@@ -15,10 +18,9 @@ class Parser:
 	A placeholder class that does something a little
 	like the real parser.
 	"""
-
 	def parse( self, src ):
-		with open( 'codetree-examples/binding.codetree.json', 'r' ) as placeholdersrc:
-			return codetree.deserialise( placeholdersrc )
+		( match, parser ) = nutmeg_extensions.findMatchingParser( src.name )
+		return parser( src, match )
 
 
 ###############################################################################
@@ -41,8 +43,8 @@ class ParseLauncher( Launcher ):
 		This is a dummy function to show how the launcher and the basic
 		functionality will relate to each other.
 		"""
-		codetree = Parser().parse( self._args.input )
-		codetree.serialise( self._args.output )
+		for codetree in Parser().parse( self._args.input ):
+			codetree.serialise( self._args.output )
 
 
 class ResolveLauncher( Launcher ):

--- a/nutmeg_extensions.py
+++ b/nutmeg_extensions.py
@@ -1,0 +1,28 @@
+import re
+from pathlib import Path
+
+# This is a list of (regex, parser) pairs. The regex is used to recognise
+# matching filenames.
+PARSER_LIST = []
+
+def NutmegParserExtension( filename_regex_string ):
+    r"""
+    Introduces a decorator for declaring parser extensions.
+    e.g. The decoration @NutmegParserExtension( r'(.*)\.gif' ) would introduce
+    a parser extension for GIF image files.
+    """
+    filename_regex = re.compile( filename_regex_string )
+    def registerParser( parser ):
+        PARSER_LIST.append( ( filename_regex, parser ) )
+        return parser
+    return registerParser
+
+def findMatchingParser( pathname ):
+    path = Path( pathname )
+    fname = path.name
+    for ( regex, parser ) in PARSER_LIST:
+        m = regex.fullmatch( fname )
+        if m:
+            return ( m, parser )
+    raise Exception( f'No parser found for file: {pathname}' )
+    


### PR DESCRIPTION
This change implements a demonstrator of decoration-based parser-extensions for Nutmeg using the recognition of file-extensions or other parts of the file name to select the correct parser. This can be used to support the main language syntax, domain specific languages (DSLs) and [autoconversion](/Spicery/Nutmeg/wiki/Autoconversion).