### PR TITLE
Use Microsoft.Data.Sqlite for .NET Core & fixes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu
 RUN apt-get update && apt-get install -y build-essential python3 wget zip
-RUN mkdir -p /tmp/nutmeg
+RUN  mkdir -p /tmp/nutmeg
+COPY compiler/ /tmp/nutmeg/compiler/
+COPY runner/ /tmp/nutmeg/runner/
+COPY scripts/ /tmp/nutmeg/scripts
+COPY Makefile /tmp/nutmeg/
 WORKDIR /tmp/nutmeg
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
@@ -8,12 +12,9 @@ RUN apt-get install -y apt-transport-https
 RUN apt-get update
 # Use the noninteractive flag to stop being prompted for timezone.
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y dotnet-sdk-3.1
-RUN wget   https://github.com/Spicery/Nutmeg/archive/integration.zip
-RUN unzip integration.zip
-WORKDIR /tmp/nutmeg/Nutmeg-integration
 RUN apt-get install -y python3-pip
 RUN pip3 install str2bool pyinstaller
 RUN make build RID=linux-x64
 RUN make install RID=linux-x64
-RUN ls /usr/local/bin 
-RUN ls /opt/nutmeg
+RUN useradd -ms /bin/bash coder
+USER coder

--- a/runner/NutmegRunner/UnitTestResults.cs
+++ b/runner/NutmegRunner/UnitTestResults.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SQLite;
+using Microsoft.Data.Sqlite;
 
 namespace NutmegRunner {
 
@@ -10,11 +10,11 @@ namespace NutmegRunner {
         private const string amber = "AMBER";
         private const string green = "GREEN";
 
-        private SQLiteConnection _connection;
+        private SqliteConnection _connection;
         private List<string> _passes = new List<string>();
         private List<Tuple<string, Exception>> _failures = new List<Tuple<string, Exception>>();
 
-        public UnitTestResults( SQLiteConnection connection ) {
+        public UnitTestResults( SqliteConnection connection ) {
             this._connection = connection;
         }
 
@@ -52,7 +52,7 @@ namespace NutmegRunner {
             }
         }
 
-        private string GetAssertFailureMessage( SQLiteConnection connection, Exception ex ) {
+        private string GetAssertFailureMessage( SqliteConnection connection, Exception ex ) {
             var msg = ex.Message;
 
             if (ex is AssertionFailureException exn) {
@@ -69,10 +69,10 @@ namespace NutmegRunner {
             return msg;
         }
 
-        private bool TryGetLine( SQLiteConnection connection, string unit, int posn, out string line ) {
+        private bool TryGetLine( SqliteConnection connection, string unit, int posn, out string line ) {
             line = null;
             if (unit == null) return false;
-            using (SQLiteCommand cmd = new SQLiteCommand( "SELECT 1 + length(substr(Contents, 0, @Posn)) - length(replace(substr(Contents, 0, @Posn), CHAR(10), '')), substr( Contents, @Posn, 80 ) FROM SourceFiles WHERE FileName = @Unit", connection )) {
+            using (SqliteCommand cmd = new SqliteCommand( "SELECT 1 + length(substr(Contents, 0, @Posn)) - length(replace(substr(Contents, 0, @Posn), CHAR(10), '')), substr( Contents, @Posn, 80 ) FROM SourceFiles WHERE FileName = @Unit", connection )) {
                 cmd.Parameters.AddWithValue( "@Posn", posn + 1 );   //  Add 1 to compensate for the 1-indexing of substr.
                 cmd.Parameters.AddWithValue( "@Unit", unit );
                 cmd.Prepare();


### PR DESCRIPTION
This pull request is made to record the changes and their motivation.

Phil Allen found that we had a problem with the Dockerfile that was pulling a zip file direct from GitHub - and hence was branch insensitive. So I fixed the Dockerfile, making it take the files from the local directory (which is plainly the sensible way to do it).

This then revealed an odd problem with the SQLite.Interop.dll. The linux-x64 build was creating a zero-byte DLL! I cannot account for why this issue only turned up now but I am guessing stale local Docker images .. maybe? Anyway it turns out that Microsoft.Data.Sqlite is preferred for .NET Core at the moment. Somewhat reluctantly I have rewritten the code to use that library instead.