### PR TITLE
V0.1/72 strings

### DIFF
--- a/compiler/optimizer.py
+++ b/compiler/optimizer.py
@@ -12,7 +12,7 @@ class ReplaceIdsWithSysconsts( codetree.CodeletVisitor ):
 
     def visitIdCodelet( self, id_codelet ):
         if syscalls.isSysconst( id_codelet.name() ):
-            raise Exception( f"sysconsts not implemented yet: {id_codelet}" )
+            raise Exception( f"sysconsts not implemented yet: {id_codelet.name()}" )
         else:
             return id_codelet
 
@@ -22,7 +22,7 @@ class ReplaceIdsWithSysconsts( codetree.CodeletVisitor ):
             # TODO: do we need to be concerned about call_codelet._kwargs?
             return SyscallCodelet( name=f.name(), arguments=call_codelet.arguments().visit( self ) )
         else:
-            return call_codelet
+            return call_codelet.transform( self )
 
 class Simplify( codetree.CodeletVisitor ):
 

--- a/compiler/parser.py
+++ b/compiler/parser.py
@@ -376,7 +376,7 @@ def inPostfixMiniParser( parser, p, lhs, token, source ):
     return codetree.InCodelet( pattern = lhs, streamable = rhs )
 
 def dotPostfixMiniParser( parser : TableDrivenParser, p, lhs, token, source : PeekablePushable ):
-    rhs = parser.readExpr( p, source )
+    rhs = parser.readExpr( p-1, source )
     if isinstance( rhs, codetree.IdCodelet ):
         return codetree.CallCodelet(function=rhs, arguments=lhs)
     elif isinstance( rhs, codetree.CallCodelet ):

--- a/compiler/syscalls.py
+++ b/compiler/syscalls.py
@@ -16,6 +16,7 @@ SYSCONSTS = (
         # Not in a module
         "<=", "<", ">=", ">",
         "==", "!=", "not",
+        "countArguments",
         # String functions - which will need to be promoted to methods soon enough.
         "get", "length",
         "startsWith", "endsWith",

--- a/compiler/syscalls.py
+++ b/compiler/syscalls.py
@@ -23,6 +23,8 @@ SYSCONSTS = (
         "contains",
         "trim", "indexOf",
         "++", "newString",
+        "split", "join",
+        "substring",
     ))
 )
 

--- a/compiler/syscalls.py
+++ b/compiler/syscalls.py
@@ -1,17 +1,27 @@
 SYSCONSTS = (
     set((
+        # Not in a module
         "println",
         "showMe",
+        # Range module
         "..<",
         "...",
         "[x..<y]",
         "[x...y]",
+        # Arith module
         "+",
         "sum",
         "-",
         "*",
+        # Not in a module
         "<=", "<", ">=", ">",
-        "==", "!=",
+        "==", "!=", "not",
+        # String functions - which will need to be promoted to methods soon enough.
+        "get", "length",
+        "startsWith", "endsWith",
+        "isSubstring", "contains",
+        "trim", "indexOf",
+        "++", "newString",
     ))
 )
 

--- a/compiler/syscalls.py
+++ b/compiler/syscalls.py
@@ -19,7 +19,7 @@ SYSCONSTS = (
         # String functions - which will need to be promoted to methods soon enough.
         "get", "length",
         "startsWith", "endsWith",
-        "isSubstring", "contains",
+        "contains",
         "trim", "indexOf",
         "++", "newString",
     ))

--- a/compiler/tokenizer.py
+++ b/compiler/tokenizer.py
@@ -282,7 +282,7 @@ token_spec = {
         TokenType( r"(?P<TERMINATE_STATEMENT>;)", make=PunctuationToken.make ),
         TokenType( r"(?P<END_PHRASE>:)", make=PunctuationToken.make ),
         TokenType( r"(?P<END_PARAMETERS>=>>)", make=PunctuationToken.make ),
-        TokenType( r"(?P<DOT>\.)", prec=10, make=SyntaxToken.make ),
+        TokenType( r"(?P<DOT>\.)", prec=11, make=SyntaxToken.make ),
         TokenType( r"(?P<LPAREN>\()", prec=10, outfix=True, make=SyntaxToken.make ),
         TokenType( r"(?P<RPAREN>\))", make=PunctuationToken.make ),
         TokenType( r"(?P<LBRACKET>\[)", outfix=True, make=SyntaxToken.make ),

--- a/runner/NutmegRunner/ArithModule.cs
+++ b/runner/NutmegRunner/ArithModule.cs
@@ -1,0 +1,71 @@
+﻿namespace NutmegRunner.Modules.Arith {
+
+    public class AddSystemFunction : FixedAritySystemFunction {
+
+        public AddSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long y = (long)runtimeEngine.PopValue();
+            long x = (long)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( x + y );
+            return this.Next;
+        }
+
+    }
+
+    public class MulSystemFunction : FixedAritySystemFunction {
+
+        public MulSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long y = (long)runtimeEngine.PopValue();
+            long x = (long)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( x * y );
+            return this.Next;
+        }
+
+    }
+
+    public class SumSystemFunction : VariadicSystemFunction {
+
+        public SumSystemFunction( Runlet next ) : base( next ) { }
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long n = 0;
+            while (runtimeEngine.TryPop( out var d )) {
+                n += (long)d;
+            }
+            runtimeEngine.PushValue( n );
+            return this.Next;
+        }
+
+    }
+
+    public class SubtractSystemFunction : FixedAritySystemFunction {
+
+        public SubtractSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long y = (long)runtimeEngine.PopValue();
+            long x = (long)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( x - y );
+            return this.Next;
+        }
+
+    }
+
+    public class ArithModule : SystemFunctionsModule {
+        public override void AddAll() {
+            Add( "+", r => new AddSystemFunction( r ), "add" );
+            Add( "*", r => new MulSystemFunction( r ), "mul" );
+            Add( "-", r => new SubtractSystemFunction( r ), "sub" );
+            Add( "sum", r => new SumSystemFunction( r ) );
+        }
+    }
+}

--- a/runner/NutmegRunner/AssertModule.cs
+++ b/runner/NutmegRunner/AssertModule.cs
@@ -1,0 +1,77 @@
+﻿using System;
+
+namespace NutmegRunner.Modules.Assert {
+
+    public class AssertTrueSystemFunction : FixedAritySystemFunction {
+
+        public AssertTrueSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 3;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            var position = runtimeEngine.PopValue();
+            var unit = runtimeEngine.PopValue();
+            switch (runtimeEngine.PopValue()) {
+                case Boolean b:
+                    if (b) return this.Next;
+                    break;
+                default:
+                    break;
+            }
+            throw new AssertionFailureException( "assert failed", unit, position );
+        }
+
+    }
+
+    public class AssertEqualsSystemFunction : FixedAritySystemFunction {
+
+        public AssertEqualsSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 4;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            var position = runtimeEngine.PopValue();
+            var unit = runtimeEngine.PopValue();
+            var y = runtimeEngine.PopValue();
+            var x = runtimeEngine.PopValue();
+            if (x?.Equals( y ) ?? y == null) {
+                return this.Next;
+            } else {
+                throw new AssertionFailureException( "assert equal failed", unit, position )
+                    .Culprit( "Left Value", $"{x}" )
+                    .Culprit( "Right Value", $"{y}" );
+            }
+        }
+
+    }
+
+    public class AssertNotEqualsSystemFunction : FixedAritySystemFunction {
+
+        public AssertNotEqualsSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 4;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            var position = runtimeEngine.PopValue();
+            var unit = runtimeEngine.PopValue();
+            var y = runtimeEngine.PopValue();
+            var x = runtimeEngine.PopValue();
+            if (!(x?.Equals( y ) ?? y == null)) {
+                return this.Next;
+            } else {
+                throw new AssertionFailureException( "assert not equals failed", unit, position )
+                    .Culprit( "Left Value", $"{x}" )
+                    .Culprit( "Right Value", $"{y}" );
+            }
+        }
+
+    }
+
+    public class AssertModule : SystemFunctionsModule {
+        public override void AddAll() {
+            Add( "assertTrue", r => new AssertTrueSystemFunction( r ) );
+            Add( "assertEquals", r => new AssertEqualsSystemFunction( r ) );
+            Add( "assertNotEquals", r => new AssertNotEqualsSystemFunction( r ) );
+        }
+    }
+}

--- a/runner/NutmegRunner/ILayeredStack.cs
+++ b/runner/NutmegRunner/ILayeredStack.cs
@@ -9,11 +9,13 @@ namespace NutmegRunner {
         public T Pop();
         public bool IsEmpty();
         public int Size();
+        public void Clear();
 
         public T Peek();
         public T PeekOrElse( T orElse = default( T ) );
         public T PeekItem( int n );
         public T PeekItemOrElse( int n, T orElse = default( T ) );
+        public void Update( int n, Func<T, T> f );
 
         public void Lock();
         public void Unlock();
@@ -85,6 +87,10 @@ namespace NutmegRunner {
             top -= 1;
         }
 
+        public void Clear() {
+            this.top = this.layer;
+        }
+
         public bool IsEmpty() {
             return this.top == this.layer;
         }
@@ -97,14 +103,6 @@ namespace NutmegRunner {
             this.dump.Push( this.layer );
             this.layer = this.top;
         }
-
-        //public void Lock( int n ) {
-        //    this.EnsureRoom( n );
-        //    this.dump.Push( this.layer );
-        //    this.layer = this.top;
-        //    Array.Fill( this.items, default( T ), this.top, n );
-        //    this.top += n;
-        //}
 
         public void Unlock() {
             try {
@@ -150,6 +148,15 @@ namespace NutmegRunner {
             }
         }
 
+        public void Update( int n, Func<T, T> f ) {
+            int index = this.top - n - 1;
+            if (this.top > this.layer + n) {
+                this.items[index] = f.Invoke( this.items[index] );
+            } else {
+                throw new NutmegException( "Not enough items on stack" );
+            }
+        }
+
         public T this[int n] {
             get {
                 if (this.layer + n < this.top) {
@@ -166,6 +173,8 @@ namespace NutmegRunner {
                 }
             }
         }
+
+
 
         public List<object> PopAllAndUnlock() {
             var all = this.PopAll();
@@ -242,6 +251,10 @@ namespace NutmegRunner {
             this.top -= 1;
         }
 
+        public void Clear() {
+            this.top = this.layer;
+        }
+
         public bool IsEmpty() {
             return this.top == this.layer;
         }
@@ -254,14 +267,6 @@ namespace NutmegRunner {
             this.dump.Push( this.layer );
             this.layer = this.top;
         }
-
-        //public void Lock( int n ) {
-        //    this.EnsureRoom( n );
-        //    this.dump.Push( this.layer );
-        //    this.layer = this.top;
-        //    Array.Fill( this.items, default( T ), this.top, n );
-        //    this.top += n;
-        //}
 
         public int RawLock( int nlocals, CheckedLayeredStack<T> src ) {
             this.EnsureRoom( nlocals );
@@ -290,11 +295,7 @@ namespace NutmegRunner {
         }
 
         public T Peek() {
-            try {
-                return this.items[this.top - 1];
-            } catch (IndexOutOfRangeException) {
-                throw new NutmegException( "Peeking at empty stack" );
-            }
+            return this.items[this.top - 1];
         }
 
         public T PeekOrElse( T orElse = default( T ) ) {
@@ -311,10 +312,15 @@ namespace NutmegRunner {
 
         public T PeekItemOrElse( int n, T orElse = default( T ) ) {
             if (this.top > this.layer + n + 1) {
-                return this.items[this.top - n];
+                return this.items[this.top - n - 1];
             } else {
                 return orElse;
             }
+        }
+
+        public void Update( int n, Func<T, T> f ) {
+            int index = this.top - n - 1;
+            this.items[index] = f.Invoke( this.items[index] );
         }
 
         public T this[int n] {

--- a/runner/NutmegRunner/Program.cs
+++ b/runner/NutmegRunner/Program.cs
@@ -204,7 +204,7 @@ namespace NutmegRunner {
 
         private SqliteCommand GetCommandForBindingsToLoad( SqliteConnection connection ) {
             if ( this._test ) {
-                var cmd = new SqliteCommand( "SELECT B.[IdName], B.[Value] FROM [Bindings] B JOIN [DependsOn] E ON E.[Needs] = B.[IdName] JOIN [Annotations] A ON A.[IdName] = E.[IdName] WHERE A.AnnotationKey='unittest'", connection );
+                var cmd = new SqliteCommand( "SELECT DISTINCT B.[IdName], B.[Value] FROM [Bindings] B JOIN [DependsOn] E ON E.[Needs] = B.[IdName] JOIN [Annotations] A ON A.[IdName] = E.[IdName] WHERE A.AnnotationKey='unittest'", connection );
                 cmd.Prepare();
                 return cmd;
             } else {

--- a/runner/NutmegRunner/RangesModule.cs
+++ b/runner/NutmegRunner/RangesModule.cs
@@ -1,0 +1,79 @@
+﻿namespace NutmegRunner.Modules.Ranges {
+
+    public class HalfOpenRangeListSystemFunction : FixedAritySystemFunction {
+
+        public HalfOpenRangeListSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long y = (long)runtimeEngine.PopValue();
+            long x = (long)runtimeEngine.PopValue();
+            var list = new HalfOpenRangeList( x, y );
+            runtimeEngine.PushValue( list );
+            return this.Next;
+        }
+
+    }
+
+    public class ClosedRangeListSystemFunction : FixedAritySystemFunction {
+
+        public ClosedRangeListSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long y = (long)runtimeEngine.PopValue();
+            long x = (long)runtimeEngine.PopValue();
+            var list = new HalfOpenRangeList( x, y + 1 );
+            runtimeEngine.PushValue( list );
+            return this.Next;
+        }
+
+    }
+
+    public class HalfOpenRangeSystemFunction : FixedAritySystemFunction {
+
+        public HalfOpenRangeSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long y = (long)runtimeEngine.PopValue();
+            long x = (long)runtimeEngine.PopValue();
+            for (long i = x; i < y; i++) {
+                runtimeEngine.PushValue( i );
+            }
+            return this.Next;
+        }
+
+    }
+
+    public class ClosedRangeSystemFunction : FixedAritySystemFunction {
+
+        public ClosedRangeSystemFunction( Runlet next ) : base( next ) { }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long y = (long)runtimeEngine.PopValue();
+            long x = (long)runtimeEngine.PopValue();
+            for (long i = x; i <= y; i++) {
+                runtimeEngine.PushValue( i );
+            }
+            return this.Next;
+        }
+
+    }
+
+
+    public class RangesModule : SystemFunctionsModule {
+        public override void AddAll() {
+            Add( "..<", r => new HalfOpenRangeSystemFunction( r ), "halfOpenRange" );
+            Add( "...", r => new ClosedRangeSystemFunction( r ), "closedRange" );
+            Add( "[x..<y]", r => new HalfOpenRangeListSystemFunction( r ), "halfOpenRangeList" );
+            Add( "[x...y]", r => new ClosedRangeListSystemFunction( r ), "closedRangeList" );
+        }
+    }
+
+}

--- a/runner/NutmegRunner/RuntimeEngine.cs
+++ b/runner/NutmegRunner/RuntimeEngine.cs
@@ -89,6 +89,10 @@ namespace NutmegRunner {
             return this._valueStack[n];
         }
 
+        public void SetItem( int n, object v ) {
+            this._valueStack[n] = v;
+        }
+
         public void PushSlot( int slot ) {
             this._valueStack.Push( this._callStack[slot] );
         }

--- a/runner/NutmegRunner/RuntimeEngine.cs
+++ b/runner/NutmegRunner/RuntimeEngine.cs
@@ -85,6 +85,10 @@ namespace NutmegRunner {
             return this._callStack[slot];
         }
 
+        public object GetItem( int n ) {
+            return this._valueStack[n];
+        }
+
         public void PushSlot( int slot ) {
             this._valueStack.Push( this._callStack[slot] );
         }
@@ -149,8 +153,16 @@ namespace NutmegRunner {
             return this._valueStack.PeekItemOrElse( n, orElse: orElse );
         }
 
+        public void Update( int n, Func<object, object> f ) {
+            this._valueStack.Update( n, f );
+        }
+
         public int ValueStackLength() {
             return this._valueStack.Size();
+        }
+
+        public void ClearValueStack() {
+            this._valueStack.Clear();
         }
 
         public void Bind( string idName, Codelet codelet ) {

--- a/runner/NutmegRunner/StringsModule.cs
+++ b/runner/NutmegRunner/StringsModule.cs
@@ -195,7 +195,7 @@ namespace NutmegRunner.Modules.Strings {
             Add( "get", r => new StringGet( r ) );
             Add( "startsWith", r => new StringStartsWith( r ) );
             Add( "endsWith", r => new StringEndsWith( r ) );
-            Add( "isSubstring", r => new StringIsSubstring( r ), "contains" );
+            Add( "contains", r => new StringIsSubstring( r ) );
             Add( "trim", r => new StringTrim( r ) );
             Add( "++", r => new StringAppend( r ) );
         }

--- a/runner/NutmegRunner/StringsModule.cs
+++ b/runner/NutmegRunner/StringsModule.cs
@@ -12,7 +12,7 @@ namespace NutmegRunner.Modules.Strings {
 
         public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
             string x = (string)runtimeEngine.PopValue();
-            runtimeEngine.PushValue( x.Length );
+            runtimeEngine.PushValue( (long)x.Length );
             return this.Next;
         }
 

--- a/runner/NutmegRunner/StringsModule.cs
+++ b/runner/NutmegRunner/StringsModule.cs
@@ -1,0 +1,204 @@
+﻿using System.Text;
+
+namespace NutmegRunner.Modules.Strings {
+
+    public class StringLength : FixedAritySystemFunction {
+
+        public StringLength( Runlet next ) : base( next ) {
+        }
+
+        public override int Nargs => 1;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            string x = (string)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( x.Length );
+            return this.Next;
+        }
+
+    }
+
+    public class StringGet : FixedAritySystemFunction {
+
+        public StringGet( Runlet next ) : base( next ) {
+        }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            long n = (long)runtimeEngine.PopValue();
+            string x = (string)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( x[(int)n] );
+            return this.Next;
+        }
+
+    }
+
+    public class StringStartsWith : FixedAritySystemFunction {
+
+        public StringStartsWith( Runlet next ) : base( next ) {
+        }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            var putativePrefix = (string)runtimeEngine.PopValue();
+            string subject = (string)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( subject.StartsWith( putativePrefix ) );
+            return this.Next;
+        }
+
+    }
+
+    public class StringEndsWith : FixedAritySystemFunction {
+
+        public StringEndsWith( Runlet next ) : base( next ) {
+        }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            var putativeSuffix = (string)runtimeEngine.PopValue();
+            string subject = (string)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( subject.EndsWith( putativeSuffix ) );
+            return this.Next;
+        }
+
+    }
+
+    public class StringIsSubstring : FixedAritySystemFunction {
+
+        public StringIsSubstring( Runlet next ) : base( next ) {
+        }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            var needle = runtimeEngine.PopValue();
+            string haystack = (string)runtimeEngine.PopValue();
+            if (needle is string needle_string) {
+                runtimeEngine.PushValue( haystack.Contains( needle_string ) );
+            } else if (needle is char needle_char) {
+                runtimeEngine.PushValue( haystack.Contains( needle_char ) );
+            }
+            return this.Next;
+        }
+
+    }
+
+
+
+    /// <summary>
+    /// Once we add optional arguments we will allow TrimLeft and TrimRight as options.
+    /// </summary>
+    public class StringTrim : FixedAritySystemFunction {
+
+        public StringTrim( Runlet next ) : base( next ) {
+        }
+
+        public override int Nargs => 1;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            string subject = (string)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( subject.Trim() );
+            return this.Next;
+        }
+
+    }
+
+    public class StringIndexOf : FixedAritySystemFunction {
+
+        public StringIndexOf( Runlet next ) : base( next ) {
+        }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            var target = runtimeEngine.PopValue();
+            string subject = (string)runtimeEngine.PopValue();
+
+            switch (target) {
+                case string s:
+                    var n0 = subject.IndexOf( s );
+                    if (n0 < 0) {
+                        throw new NutmegException( "Cannot find index" ).Culprit( "Subject", subject ).Culprit( "Argument", s );
+                    } else {
+                        runtimeEngine.PushValue( (long)n0 );
+                    }
+                    break;
+                case char c:
+                    var n1 = subject.IndexOf( c );
+                    if (n1 < 0) {
+                        throw new NutmegException( "Cannot find index" ).Culprit( "Subject", subject ).Culprit( "Argument", $"{c}" );
+                    } else {
+                        runtimeEngine.PushValue( (long)n1 );
+                    }
+                    break;
+                default:
+                    throw new NutmegException( "Invalid argument for indexOf" )
+                        .Culprit( "Argument", $"{target}")
+                        .Hint( "Argument must be a char or a string" );
+            }
+
+            return this.Next;
+        }
+
+    }
+
+    public class StringAppend : FixedAritySystemFunction {
+
+        public StringAppend( Runlet next ) : base( next ) {
+        }
+
+        public override int Nargs => 2;
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            string obj = (string)runtimeEngine.PopValue();
+            string subject = (string)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( subject + obj );
+            return this.Next;
+        }
+
+    }
+
+    public class StringNewString : VariadicSystemFunction {
+
+        public StringNewString( Runlet next ) : base( next ) {
+        }
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            int n = runtimeEngine.ValueStackLength();
+            var b = new StringBuilder();
+            for ( int i = 0; i < n; i++ ) {
+                var item = runtimeEngine.GetItem( i );
+                switch ( item ) {
+                    case char ch:
+                        b.Append( ch );
+                        break;
+                    case string s:
+                        b.Append( s );
+                        break;
+                    default:
+                        throw new NutmegException( "Invalid argument for newString" ).Culprit( "Argument", $"{item}" );
+                }
+            }
+            runtimeEngine.ClearValueStack();
+            runtimeEngine.PushValue( b.ToString() );
+            return this.Next;
+        }
+    }
+
+    public class StringsModule : SystemFunctionsModule {
+
+        public override void AddAll() {
+            Add( "newString", r => new StringNewString( r ) );
+            Add( "length", r => new StringLength( r ) );
+            Add( "get", r => new StringGet( r ) );
+            Add( "startsWith", r => new StringStartsWith( r ) );
+            Add( "endsWith", r => new StringEndsWith( r ) );
+            Add( "isSubstring", r => new StringIsSubstring( r ), "contains" );
+            Add( "trim", r => new StringTrim( r ) );
+            Add( "++", r => new StringAppend( r ) );
+        }
+
+    }
+}

--- a/runner/NutmegRunner/StringsModule.cs
+++ b/runner/NutmegRunner/StringsModule.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 
 namespace NutmegRunner.Modules.Strings {
 
@@ -17,17 +18,24 @@ namespace NutmegRunner.Modules.Strings {
 
     }
 
-    public class StringGet : FixedAritySystemFunction {
+    public class StringGet : VariadicSystemFunction {
 
         public StringGet( Runlet next ) : base( next ) {
         }
 
-        public override int Nargs => 2;
-
         public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long n = (long)runtimeEngine.PopValue();
-            string x = (string)runtimeEngine.PopValue();
-            runtimeEngine.PushValue( x[(int)n] );
+            int length = runtimeEngine.ValueStackLength();
+            if (length >= 1) {
+                string x = (string)runtimeEngine.GetItem( 0 );
+                for (int i = 1; i < length; i++) {
+                    long index = (long)runtimeEngine.GetItem( i );
+                    runtimeEngine.SetItem( i - 1, x[(int)index] );
+                }
+                //  Discard one value.
+                runtimeEngine.PopValue();
+            } else {
+                throw new Exception( "No arguments for get (at least 1 needed)" );
+            }
             return this.Next;
         }
 

--- a/runner/NutmegRunner/SystemFunction.cs
+++ b/runner/NutmegRunner/SystemFunction.cs
@@ -178,18 +178,19 @@ namespace NutmegRunner {
 
         public override int Nargs => 1;
 
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            object x = runtimeEngine.PopValue();
+        public static IEnumerator<object> ToStream( object x ) {
             switch (x) {
                 case IEnumerable<object> e:
-                    runtimeEngine.PushValue( e.GetEnumerator() );
-                    break;
+                    return e.GetEnumerator();
                 case string s:
-                    runtimeEngine.PushValue( new StringToEnumerator( s.GetEnumerator() ) );
-                    break;
+                    return new StringToEnumerator( s.GetEnumerator() );
                 default:
                     throw new NutmegException( $"Cannot stream this object: {x}" );
             }
+        }
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            runtimeEngine.PushValue( ToStream( runtimeEngine.PopValue() ) );
             return this.Next;
         }
 

--- a/runner/NutmegRunner/SystemFunction.cs
+++ b/runner/NutmegRunner/SystemFunction.cs
@@ -1,5 +1,10 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
+using NutmegRunner.Modules.Arith;
+using NutmegRunner.Modules.Assert;
+using NutmegRunner.Modules.Ranges;
+using NutmegRunner.Modules.Strings;
 
 namespace NutmegRunner {
 
@@ -18,9 +23,51 @@ namespace NutmegRunner {
 
         public override IEnumerable<Runlet> Neighbors() {
             return new List<Runlet> { Next };
-        }        
+        }
 
     }
+
+    public abstract class SystemFunctionsModule {
+        readonly LookupTableBuilder builder = new LookupTableBuilder();
+
+        public abstract void AddAll();
+
+        public void Add( string name, SystemFunctionMaker m, params string[] synonyms ) {
+            this.builder.Add( name, m, synonyms );
+        }
+
+        public LookupTableBuilder LookupTableBuilder() {
+            this.AddAll();
+            return this.builder;
+        }
+    }
+
+    public delegate SystemFunction SystemFunctionMaker( Runlet next );
+
+    public class LookupTableBuilder {
+
+        public Dictionary<string, SystemFunctionMaker> Table { get; } = new Dictionary<string, SystemFunctionMaker>();
+
+        public LookupTableBuilder Add( string sysname, SystemFunctionMaker f, params string[] synonyms ) {
+            this.Table.Add( sysname, f );
+            foreach (var name in synonyms) {
+                this.Table.Add( name, f );
+            }
+            return this;
+        }
+
+        public LookupTableBuilder Add( SystemFunctionsModule module ) {
+            LookupTableBuilder b = module.LookupTableBuilder();
+            foreach ( var item in b.Table ) {
+                this.Add( item.Key, item.Value );
+            }
+            return this;
+        }
+
+    }
+
+
+    ////////////////////////////////////////////////////////////////
 
     public abstract class FixedAritySystemFunction : SystemFunction {
 
@@ -47,7 +94,7 @@ namespace NutmegRunner {
             var sep = " ";
             var first = true;
             foreach (var item in runtimeEngine.PopAll()) {
-                if ( ! first ) {
+                if (!first) {
                     Console.Write( sep );
                 }
                 Console.Write( $"{item}" );
@@ -105,6 +152,26 @@ namespace NutmegRunner {
 
     }
 
+    class StringToEnumerator : IEnumerator<object> {
+
+        CharEnumerator _src;
+
+        public StringToEnumerator( CharEnumerator src ) {
+            this._src = src;
+        }
+
+        public object Current => this._src.Current;
+
+        public void Dispose() {
+            this._src.Dispose();
+        }
+
+        public bool MoveNext() => this._src.MoveNext();
+
+        public void Reset() => this._src.Reset();
+
+    }
+
     public class StreamSystemFunction : FixedAritySystemFunction {
 
         public StreamSystemFunction( Runlet next ) : base( next ) { }
@@ -116,6 +183,9 @@ namespace NutmegRunner {
             switch (x) {
                 case IEnumerable<object> e:
                     runtimeEngine.PushValue( e.GetEnumerator() );
+                    break;
+                case string s:
+                    runtimeEngine.PushValue( new StringToEnumerator( s.GetEnumerator() ) );
                     break;
                 default:
                     throw new NutmegException( $"Cannot stream this object: {x}" );
@@ -135,131 +205,8 @@ namespace NutmegRunner {
         }
     }
 
-    public class HalfOpenRangeListSystemFunction : FixedAritySystemFunction {
 
-        public HalfOpenRangeListSystemFunction( Runlet next ) : base( next ) { }
 
-        public override int Nargs => 2;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long y = (long)runtimeEngine.PopValue();
-            long x = (long)runtimeEngine.PopValue();
-            var list = new HalfOpenRangeList( x, y );
-            runtimeEngine.PushValue( list );
-            return this.Next;
-        }
-
-    }
-
-    public class ClosedRangeListSystemFunction : FixedAritySystemFunction {
-
-        public ClosedRangeListSystemFunction( Runlet next ) : base( next ) { }
-
-        public override int Nargs => 2;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long y = (long)runtimeEngine.PopValue();
-            long x = (long)runtimeEngine.PopValue();
-            var list = new HalfOpenRangeList( x, y + 1 );
-            runtimeEngine.PushValue( list );
-            return this.Next;
-        }
-
-    }
-
-    public class HalfOpenRangeSystemFunction : FixedAritySystemFunction {
-
-        public HalfOpenRangeSystemFunction( Runlet next ) : base( next ) { }
-
-        public override int Nargs => 2;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long y = (long)runtimeEngine.PopValue();
-            long x = (long)runtimeEngine.PopValue();
-            for (long i = x; i < y; i++) {
-                runtimeEngine.PushValue( i );
-            }
-            return this.Next;
-        }
-
-    }
-
-    public class ClosedRangeSystemFunction : FixedAritySystemFunction {
-
-        public ClosedRangeSystemFunction( Runlet next ) : base( next ) { }
-
-        public override int Nargs => 2;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long y = (long)runtimeEngine.PopValue();
-            long x = (long)runtimeEngine.PopValue();
-            for (long i = x; i <= y; i++) {
-                runtimeEngine.PushValue( i );
-            }
-            return this.Next;
-        }
-
-    }
-
-    public class AddSystemFunction : FixedAritySystemFunction {
-
-        public AddSystemFunction( Runlet next ) : base( next ) { }
-
-        public override int Nargs => 2;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long y = (long)runtimeEngine.PopValue();
-            long x = (long)runtimeEngine.PopValue();
-            runtimeEngine.PushValue( x + y );
-            return this.Next;
-        }
-
-    }
-
-    public class MulSystemFunction : FixedAritySystemFunction {
-
-        public MulSystemFunction( Runlet next ) : base( next ) { }
-
-        public override int Nargs => 2;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long y = (long)runtimeEngine.PopValue();
-            long x = (long)runtimeEngine.PopValue();
-            runtimeEngine.PushValue( x * y );
-            return this.Next;
-        }
-
-    }
-
-    public class SumSystemFunction : VariadicSystemFunction {
-
-        public SumSystemFunction( Runlet next ) : base( next ) { }
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long n = 0;
-            while ( runtimeEngine.TryPop( out var d ) ) {
-                n += (long)d;
-            }
-            runtimeEngine.PushValue( n );
-            return this.Next;
-        }
-
-    }
-
-    public class SubtractSystemFunction : FixedAritySystemFunction {
-
-        public SubtractSystemFunction( Runlet next ) : base( next ) { }
-
-        public override int Nargs => 2;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            long y = (long)runtimeEngine.PopValue();
-            long x = (long)runtimeEngine.PopValue();
-            runtimeEngine.PushValue( x - y );
-            return this.Next;
-        }
-
-    }
 
     public class LTESystemFunction : FixedAritySystemFunction {
 
@@ -344,93 +291,23 @@ namespace NutmegRunner {
         public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
             var y = runtimeEngine.PopValue();
             var x = runtimeEngine.PopValue();
-            runtimeEngine.PushValue( !( x?.Equals( y ) ?? y == null ) );
+            runtimeEngine.PushValue( !(x?.Equals( y ) ?? y == null) );
             return this.Next;
         }
     }
 
-    public class AssertTrueSystemFunction : FixedAritySystemFunction {
+    public class NotSystemFunction : FixedAritySystemFunction {
 
-        public AssertTrueSystemFunction( Runlet next ) : base( next ) { }
+        public NotSystemFunction( Runlet next ) : base( next ) { }
 
-        public override int Nargs => 3;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            var position = runtimeEngine.PopValue();
-            var unit = runtimeEngine.PopValue();
-            switch (runtimeEngine.PopValue()) {
-                case Boolean b:
-                    if (b) return this.Next;
-                    break;
-                default:
-                    break;
-            }
-            throw new AssertionFailureException( "assert failed", unit, position );
-        }
-
-    }
-
-    public class AssertEqualsSystemFunction : FixedAritySystemFunction {
-
-        public AssertEqualsSystemFunction( Runlet next ) : base( next ) { }
-
-        public override int Nargs => 4;
+        public override int Nargs => 1;
 
         public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            var position = runtimeEngine.PopValue();
-            var unit = runtimeEngine.PopValue();
-            var y = runtimeEngine.PopValue();
-            var x = runtimeEngine.PopValue();
-            if (x?.Equals( y ) ?? y == null) {
-                return this.Next;
-            } else {
-                throw new AssertionFailureException( "assert equal failed", unit, position )
-                    .Culprit( "Left Value", $"{x}" )
-                    .Culprit( "Right Value", $"{y}" );
-            }
+            runtimeEngine.Update( 0, x => !(bool)x );
+            return this.Next;
         }
 
     }
-
-    public class AssertNotEqualsSystemFunction : FixedAritySystemFunction {
-
-        public AssertNotEqualsSystemFunction( Runlet next ) : base( next ) { }
-
-        public override int Nargs => 4;
-
-        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
-            var position = runtimeEngine.PopValue();
-            var unit = runtimeEngine.PopValue();
-            var y = runtimeEngine.PopValue();
-            var x = runtimeEngine.PopValue();
-            if ( !( x?.Equals( y ) ?? y == null ) ) {
-                return this.Next;
-            } else {
-                throw new AssertionFailureException( "assert not equals failed", unit, position )
-                    .Culprit( "Left Value", $"{x}" )
-                    .Culprit( "Right Value", $"{y}" );
-            }
-        }
-
-    }
-
-    public delegate SystemFunction SystemFunctionMaker( Runlet next );
-
-    public class LookupTableBuilder {
-
-        public Dictionary<string, SystemFunctionMaker> Table { get; } = new Dictionary<string, SystemFunctionMaker>();
-
-        public LookupTableBuilder Add( string sysname, SystemFunctionMaker f, params string[] synonyms ) {
-            this.Table.Add( sysname, f );
-            foreach ( var name in synonyms ) {
-                this.Table.Add( name, f );
-            }
-            return this;
-        }
-
-    }
-
-
 
     public class NutmegSystem {
 
@@ -438,24 +315,19 @@ namespace NutmegRunner {
             new LookupTableBuilder()
             .Add( "println", r => new PrintlnSystemFunction( r ) )
             .Add( "showMe", r => new ShowMeSystemFunction( r ) )
-            .Add( "..<", r => new HalfOpenRangeSystemFunction( r ), "halfOpenRange" )
-            .Add( "...", r => new ClosedRangeSystemFunction( r ), "closedRange" )
-            .Add( "[x..<y]", r => new HalfOpenRangeListSystemFunction( r ), "halfOpenRangeList" )
-            .Add( "[x...y]", r => new ClosedRangeListSystemFunction( r ), "closedRangeList" )
-            .Add( "+", r => new AddSystemFunction( r ), "add" )
-            .Add( "*", r => new MulSystemFunction( r ), "mul" )
-            .Add( "-", r => new SubtractSystemFunction( r ), "sub" )
-            .Add( "sum", r => new SumSystemFunction( r ) )
+
             .Add( "==", r => new EqualsSystemFunction( r ) )
             .Add( "!=", r => new NotEqualsSystemFunction( r ) )
             .Add( "<=", r => new LTESystemFunction( r ), "lessThanOrEqualTo" )
             .Add( "<", r => new LTSystemFunction( r ), "lessThan" )
             .Add( ">=", r => new GTESystemFunction( r ), "greaterThanOrEqualTo" )
             .Add( ">", r => new GTSystemFunction( r ), "greaterThan" )
+            .Add( "not", r => new NotSystemFunction( r ) )
             .Add( "newImmutableList", r => new ListSystemFunction( r ) )
-            .Add( "assertTrue", r => new AssertTrueSystemFunction( r ) )
-            .Add( "assertEquals", r => new AssertEqualsSystemFunction( r ) )
-            .Add( "assertNotEquals", r => new AssertNotEqualsSystemFunction( r ) )
+            .Add( new ArithModule() )
+            .Add( new RangesModule() )
+            .Add( new AssertModule() )
+            .Add( new StringsModule() )
             .Table;
 
         public static SystemFunctionMaker Find( string name ) {

--- a/runner/NutmegRunner/SystemFunction.cs
+++ b/runner/NutmegRunner/SystemFunction.cs
@@ -309,6 +309,17 @@ namespace NutmegRunner {
 
     }
 
+    public class CountArgumentsSystemFunction : VariadicSystemFunction {
+        public CountArgumentsSystemFunction( Runlet next ) : base( next ) { }
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            int n = runtimeEngine.ValueStackLength();
+            runtimeEngine.ClearValueStack();
+            runtimeEngine.PushValue( (long)n );
+            return this.Next;
+        }
+    }
+
     public class NutmegSystem {
 
         static readonly Dictionary<string, SystemFunctionMaker> SYSTEM_FUNCTION_TABLE =
@@ -324,6 +335,7 @@ namespace NutmegRunner {
             .Add( ">", r => new GTSystemFunction( r ), "greaterThan" )
             .Add( "not", r => new NotSystemFunction( r ) )
             .Add( "newImmutableList", r => new ListSystemFunction( r ) )
+            .Add( "countArguments", r => new CountArgumentsSystemFunction( r ) )
             .Add( new ArithModule() )
             .Add( new RangesModule() )
             .Add( new AssertModule() )

--- a/runner/NutmegRunnerTests/ILayeredStackTests.cs
+++ b/runner/NutmegRunnerTests/ILayeredStackTests.cs
@@ -267,7 +267,7 @@ namespace NutmegRunnerTests {
             //  Arrange
             var stack = new UncheckedLayeredStack<string>();
             //  Assert
-            Assert.Throws<NutmegException>( () => stack.Peek() );
+            Assert.Throws<System.IndexOutOfRangeException>( () => stack.Peek() );
         }
 
         [Fact]

--- a/runner/NutmegRunnerTests/Runlet_Tests.cs
+++ b/runner/NutmegRunnerTests/Runlet_Tests.cs
@@ -2,7 +2,6 @@
 using NutmegRunner;
 using Xunit;
 
-
 namespace NutmegRunnerTests {
 
     public class JumpToJump_Runlet_Tests {

--- a/runner/NutmegRunnerTests/SystemFunctionTests.cs
+++ b/runner/NutmegRunnerTests/SystemFunctionTests.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using NutmegRunner;
+using NutmegRunner.Modules.Ranges;
+using NutmegRunner.Modules.Strings;
 using Xunit;
 
-
-namespace NutmegRunnerTests
-{
+namespace NutmegRunnerTests {
 
     public class HalfOpenRangeSystemFunction_Tests
     {
@@ -239,6 +238,22 @@ namespace NutmegRunnerTests
                 Assert.Equal(n++, i);
             }
             Assert.Equal(16L, n);
+        }
+
+
+        [Fact]
+        public void String_Get_Test() {
+            //  Arrange
+            var runtime = new RuntimeEngine( false );
+            runtime.LockValueStack();
+            runtime.PushValue( "foo" );
+            runtime.PushValue( 0L );
+            var empty = new StringGet( null );
+            //  Act
+            empty.ExecuteRunlet( runtime );
+            var c = runtime.PopValue1();
+            //  Assert
+            Assert.Equal( "foo"[0], c );
         }
 
     }


### PR DESCRIPTION
Add the following system-calls to support strings. Note that most of these are deliberately given names that will need to belong to methods in the near future.

 newString( (char|string)* ) -> string
 string.length -> int
 string.get( int* ) -> character
 string.startsWith( string )
 string.endsWith( string )
 string.substring( range* ) -> string
 string.contains( string ) -> bool
 string.indexOf( char|string ) -> int | Absent() - we either need escapes (returns) or series to do this properly
 string == string -> bool
 string ++ string -> string
 string.trim -> string
 string.split() -> string*
 string.join(string*) -> string