### PR TITLE
Pass command-line arguments to the @command

### DIFF
--- a/runner/NutmegRunner/ILayeredStack.cs
+++ b/runner/NutmegRunner/ILayeredStack.cs
@@ -286,8 +286,11 @@ namespace NutmegRunner {
             this.EnsureRoom( nlocals );
             this.Lock();
             var nargs = src.RawSend( this );
-            Array.Fill( this.items, default( T ), this.top + nargs, nlocals - nargs );
-            this.top += nlocals;
+            if (nlocals >= nargs) {
+                //  If this branch is not taken then an error will be raised when nargs is detected to be wrong.
+                Array.Fill( this.items, default( T ), this.top + nargs, nlocals - nargs );
+                this.top += nlocals;
+            } 
             return nargs;
         }
 

--- a/runner/NutmegRunner/Program.cs
+++ b/runner/NutmegRunner/Program.cs
@@ -15,6 +15,7 @@ namespace NutmegRunner {
         string _graphviz = null;
         bool _print = false;
         bool _test = false;
+        LinkedList<string> _args;
 
         public bool Trace => this._trace;
 
@@ -29,6 +30,7 @@ namespace NutmegRunner {
         private Program(LinkedList<string> args) {
             ProcessRunnerOptions( args );
             ProcessBundleFile( args );
+            this._args = args;
         }
 
         private void ProcessBundleFile( LinkedList<string> args ) {
@@ -176,7 +178,7 @@ namespace NutmegRunner {
                         foreach (var idName in tests_to_run) {
                             if (this._debug) Console.WriteLine( $"Running unit test for {idName}" );
                             try {
-                                runtimeEngine.Start( idName, useEvaluate: false, usePrint: this._print );
+                                runtimeEngine.Start( idName, new List<string>(), useEvaluate: false, usePrint: this._print );
                                 utresults.AddPass( idName );
                             } catch (Exception ex) {
                                 utresults.AddFailure( idName, ex );
@@ -187,7 +189,7 @@ namespace NutmegRunner {
                         utresults.ShowResults();
                     }
                 } else {
-                    runtimeEngine.Start( this._entryPoint, useEvaluate: false, usePrint: this._print );
+                    runtimeEngine.Start( this._entryPoint, this._args, useEvaluate: false, usePrint: this._print );
                 }
             } catch (SqliteException sqlexn) {
                 if (sqlexn.SqliteErrorCode == 26) {

--- a/runner/NutmegRunnerTests/CodeletTests.cs
+++ b/runner/NutmegRunnerTests/CodeletTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NutmegRunner;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace NutmegRunnerTests {
             var s = Encapsulate( new StringCodelet( arbitraryString ) );
             var rte = new RuntimeEngine(false);
             //  Act
-            rte.StartFromCodelet(s, useEvaluate: false, usePrint: false);
+            rte.StartFromCodelet(s, new List<string>(), useEvaluate: false, usePrint: false);
             //  Assert
             Assert.Equal( 1, rte.ValueStackLength() );
             Assert.Equal( arbitraryString, rte.PeekOrElse() );


### PR DESCRIPTION
With this update, @command procedures are passed arguments from the command line. We also fix an issue with detecting a mismatch in the number of arguments passed to a procedure.