### PR TITLE
Adds Python-like number tokens

### DIFF
--- a/compiler/parser.py
+++ b/compiler/parser.py
@@ -335,7 +335,7 @@ PREFIX_TABLE = {
     BasicToken: lambda parser, token, source: codetree.StringCodelet( value=token.value() ),
     IdToken: lambda parser, token, source: codetree.IdCodelet( name=token.value(), reftype="get" ),
     CharToken: lambda parser, token, source: codetree.CharCodelet( value=token.literalValue() ),
-    IntToken: lambda parser, token, source: codetree.IntCodelet( value=token.value() ),
+    IntToken: lambda parser, token, source: codetree.IntCodelet( value=str( token.valueAsInt() ) ),
     BoolToken: lambda parser, token, source: codetree.BoolCodelet( value=token.value() ),
     StringToken: lambda parser, token, source: codetree.StringCodelet( value=token.literalValue() ),
     "DEC_VARIABLE": varPrefixMiniParser,

--- a/compiler/test/test_tokenizer.py
+++ b/compiler/test/test_tokenizer.py
@@ -13,7 +13,7 @@ def help_test( *testcases ):
         assert testcase[1] == tokenize( testcase[0] )
 
 def test_ints():
-    for text in [ '42', '1805', '9999999999999999999999' ]:
+    for text in [ '42', '1805', '9999999999999999999999', '-7', '0xFF', '-0b1010' ]:
         t = tokenizeOne( text )
         assert isinstance( t, IntToken )
         assert t.value() == text

--- a/compiler/tokenizer.py
+++ b/compiler/tokenizer.py
@@ -169,6 +169,9 @@ class IntToken( Token ):
     def category( self ):
         return type(self)
 
+    def valueAsInt( self ):
+        return int( self._value, base=0 )
+
 class CharToken( Token ):
 
     @staticmethod
@@ -301,11 +304,13 @@ class TokenType:
 token_spec = {
     tt.idname(): tt for tt in [
         # literal_constants
-        TokenType( r"(?P<INT>(\+|-)?\d+)", make=IntToken.make ),
+        TokenType( r"(?P<HEXINT>(\+|-)?0x_?[\dA-F]+(?:_[A-F\d]+)*)", make=IntToken.make ),
+        TokenType( r"(?P<BOOLINT>(\+|-)?0b_?[01]+(?:_[01_]+)*)", make=IntToken.make ),
+        TokenType( r"(?P<INT>(\+|-)?[1-9]\d*(?:_\d+)*)", make=IntToken.make ),
+        TokenType( r"(?P<ZEROINT>(\+|-)?0)", make=IntToken.make ),
         TokenType( r"(?P<CHAR>\`[^\n\`]\`)", make=CharToken.make ),
         TokenType( r'(?P<DQSTRING>(?!""")"[^\n"]*")', make=StringToken.make ),
         TokenType( r"(?P<SQSTRING>(?!''')'[^\n']*')", make=StringToken.make ),
-        #TokenType( r'(?P<SQSTRING>"""(?:(?!""").)*""")', make=StringToken.make ),
         TokenType( r'(?P<MULTILINE_DQSTRING>"""(?:(?!""").)*""")', make=StringToken.make ),
         TokenType( r"(?P<MULTILINE_SQSTRING>'''(?:(?!''').)*''')", make=StringToken.make ),
         TokenType( r"(?P<BOOL>true|false)", make=BoolToken.make ),


### PR DESCRIPTION
This change allows underscores in numbers and also allows hex and binary numbers with underscores, following Python-like rules. We may want to revisit this to permit a wider range of formats (e.g. consecutive underscores & leading zeros). But this is good enough for now.