### PR TITLE
Implements lambda lifting via an internal 'function' called partApply

### DIFF
--- a/compiler/codetree.py
+++ b/compiler/codetree.py
@@ -249,6 +249,18 @@ class IdCodelet( Codelet ):
 		self._nonassignable = nonassignable
 		self._const = const
 
+	def copy( self, label=None ):
+		return IdCodelet(
+			name=self._name,
+			reftype=self._reftype,
+			slot=self._slot,
+			const=self._const,
+			nonassignable=self._nonassignable,
+			scope=self._scope,
+			label=( label or self._label ),
+			**self._kwargs
+		)
+
 	def members( self ):
 		yield from ()
 
@@ -751,12 +763,19 @@ class LambdaCodelet( Codelet ):
 
 	KIND = "lambda"
 
-	def __init__( self, *, parameters, body, nlocals = None, nargs = None, **kwargs ):
+	def __init__( self, *, parameters, body, captured=[], nlocals = None, nargs = None, **kwargs ):
 		super().__init__( **kwargs )
 		self._parameters = parameters
 		self._body = body
 		self._nlocals = nlocals
 		self._nargs = nargs
+		self._captured = set(captured)
+
+	def captured( self ):
+		return self._captured
+
+	def capture( self, name ):
+		self._captured.add( name )
 
 	def members( self ):
 		yield self.parameters()
@@ -784,7 +803,7 @@ class LambdaCodelet( Codelet ):
 		self._nargs = n
 
 	def encodeAsJSON( self, encoder ):
-		d = dict( kind=self.KIND, parameters=self._parameters, body=self._body, **self._kwargs )
+		d = dict( kind=self.KIND, parameters=self._parameters, body=self._body, captured=list(self._captured), **self._kwargs )
 		if self._nlocals is not None:
 			d[ 'nlocals' ] = self._nlocals
 		if self._nargs is not None:

--- a/compiler/parser.py
+++ b/compiler/parser.py
@@ -128,6 +128,14 @@ class TableDrivenParser:
         else:
             return funcargs
 
+    def readArgs( self, source ):
+        args = self.readExpr( math.inf, source )
+        issue = TableDrivenParser.isntArgs( args )
+        if issue:
+            raise Exception( f'Invalid expression for lambda definition ({issue})' )
+        else:
+            return args
+
     def isVirtualSemi( self, nonsemi ):
         if not nonsemi.followsNewLine():
             return False
@@ -226,6 +234,13 @@ def defPrefixMiniParser( parser, token, source ):
     func = codetree.LambdaCodelet( parameters=args, body=b )
     return codetree.BindingCodelet( lhs=id, rhs=func )
 
+def fnPrefixMiniParser( parser, token, source ):
+    args = parser.readArgs( source )
+    args.declarationMode()
+    mustRead( source, 'END_PARAMETERS', 'END_PHRASE', expected=': or =>>' )
+    b = parser.readStatements( source )
+    mustRead( source, 'ENDFN', 'END', expected='end or endfn' )
+    return codetree.LambdaCodelet( parameters=args, body=b )
 
 def wuntilPrefixMiniParser( parser, token, source ):
     lhs = codetree.NonStopCodelet()
@@ -335,6 +350,7 @@ PREFIX_TABLE = {
     "LPAREN": lparenPrefixMiniParser,
     "LBRACKET": lbracketPrefixMiniParser,
     "DEC_FUNCTION_1": defPrefixMiniParser,
+    "FN": fnPrefixMiniParser,
     "IF": ifPrefixMiniParser,
     "IFNOT": ifnotPrefixMiniParser,
     "FOR": forPrefixMiniParser,

--- a/compiler/tokenizer.py
+++ b/compiler/tokenizer.py
@@ -369,6 +369,9 @@ token_spec = {
         TokenType( r"(?P<AFTERWARDS>afterwards\b)", prec=910, prefix=False, outfix=False, make=SyntaxToken.make ),
         TokenType( r"(?P<DO>do\b)", make=PunctuationToken.make ),
         TokenType( r"(?P<ENDFOR>endfor\b)", make=PunctuationToken.make ),
+        TokenType( r"(?P<FN>fn\b)", outfix=True, make=SyntaxToken.make ),
+        TokenType( r"(?P<ENDFN>endfn\b)", make=PunctuationToken.make ),
+
         TokenType( r"(?P<ASSERT>assert\b)", make=SyntaxToken.make ),
 
         TokenType( r"(?P<END>end\b)", make=PunctuationToken.make ),  # MUST come after all other end... token types.

--- a/runner/NutmegRunner/Runlet.cs
+++ b/runner/NutmegRunner/Runlet.cs
@@ -346,8 +346,29 @@ namespace NutmegRunner {
 
     }
 
-    interface ICallable {
+    public interface ICallable {
         Runlet Call( RuntimeEngine runtimeEngine, Runlet next, bool alt );
+    }
+
+    public class PartialApplication : RunletWithNext, ICallable {
+
+        ICallable _fn;
+        IList<object> _args;
+
+        public PartialApplication( ICallable fn, IList<object> args, Runlet next ) : base( next ) {
+            _fn = fn;
+            _args = args;
+        }
+
+        public Runlet Call( RuntimeEngine runtimeEngine, Runlet next, bool alt ) {
+            runtimeEngine.PushAll( _args );
+            return _fn.Call( runtimeEngine, next, alt );
+        }
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            runtimeEngine.PushValue( this );
+            return this.Next;
+        }
     }
 
     public class FunctionRunlet : RunletWithNext, ICallable
@@ -385,7 +406,7 @@ namespace NutmegRunner {
         public override Runlet ExecuteRunlet(RuntimeEngine runtimeEngine)
         {
             runtimeEngine.PushValue(this);
-            return this._next;
+            return this.Next;
         }
 
         public override IEnumerable<Runlet> Neighbors() {

--- a/runner/NutmegRunner/RuntimeEngine.cs
+++ b/runner/NutmegRunner/RuntimeEngine.cs
@@ -105,6 +105,13 @@ namespace NutmegRunner {
             this._valueStack.Push( value );
         }
 
+        public void PushAll( IList<object> args ) {
+            //  TODO: This can be sped up.
+            foreach ( var x in args ) {
+                this._valueStack.Push( x );
+            }
+        }
+
         public object PopValue() {
             return this._valueStack.Pop();
         }

--- a/runner/NutmegRunner/SystemFunction.cs
+++ b/runner/NutmegRunner/SystemFunction.cs
@@ -394,6 +394,18 @@ namespace NutmegRunner {
         }
     }
 
+    public class PartApplySystemFunction : VariadicSystemFunction {
+        public PartApplySystemFunction( Runlet next ) : base( next ) { }
+
+        public override Runlet ExecuteRunlet( RuntimeEngine runtimeEngine ) {
+            int N = runtimeEngine.ValueStackLength();
+            var args = runtimeEngine.PopMany( N - 1 );
+            ICallable fn = (ICallable)runtimeEngine.PopValue();
+            runtimeEngine.PushValue( new PartialApplication( fn, args, null ) );
+            return this.Next;
+        }
+    }
+
     public class NutmegSystem {
 
         static readonly Dictionary<string, SystemFunctionMaker> SYSTEM_FUNCTION_TABLE =
@@ -411,6 +423,7 @@ namespace NutmegRunner {
             .Add( "newImmutableList", r => new ListSystemFunction( r ) )
             .Add( "countArguments", r => new CountArgumentsSystemFunction( r ) )
             .Add( "dup", r => new DupSystemFunction( r ) )
+            .Add( "partApply", r => new PartApplySystemFunction( r ) )
             .Add( new ArithModule() )
             .Add( new RangesModule() )
             .Add( new AssertModule() )


### PR DESCRIPTION
Implements a reasonably efficient form of closures. It relies on an enhanced resolve phase marking up the captured-variables via a volatile property _captured. This property is volatile in the sense that it is not published to the JSON output. Hence it only works if the optimize phase that consumes it is scheduled immediately afterwards.